### PR TITLE
Fix parallax view display

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,9 @@
     "start": "node_modules/react-native/packager/packager.sh"
   },
   "dependencies": {
-    "fetch": "^0.3.6",
     "react-native": "^0.4.2",
     "react-native-blur": "^0.4.2",
-    "react-native-parallax-view": "^1.0.2",
+    "react-native-parallax-view": "git://github.com/lelandrichardson/react-native-parallax-view",
     "react-native-vector-icons": "^0.6.1",
     "react-timer-mixin": "^0.13.1"
   }


### PR DESCRIPTION
Check https://github.com/lelandrichardson/react-native-parallax-view/issues/4. The fix it's on master, but since the author didn't update the npm package, we need to point to the repo itself.

![image](https://cloud.githubusercontent.com/assets/2805320/8143841/501b076c-11c9-11e5-9b9b-1090f65077f7.png)
- [x] add github repo for `react-native-parallax-view`
