### PR TITLE
Add BuddyBuild Badge to Dribbble App

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=55e0b1142844140100bcff33&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/55e0b1142844140100bcff33/build/latest)
+
 ###Dribbble app built with React Native
 
 A [Dribbble](http://dribbble.com) app build with [React Native](https://github.com/facebook/react-native).


### PR DESCRIPTION
Hello owners of Dribbble App!

We have successfully onboarded Dribbble App into BuddyBuild! 

This pull request embeds a badge in your README - allowing you to quickly determine the build status of Dribbble App.

Cheers!
BuddyBuildTeam