### PR TITLE
Fixed git clone path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Plugins used:
 
 ####How to run it locally
 
-- Clone this repo `git clone git@github.com:catalinmiron/react-native-dribbble-app.git`
+- Clone this repo `git clone https://github.com/catalinmiron/react-native-dribbble-app.git`
 - `cd react-native-dribbble-app`
 - run `npm install`
 - Open `DribbbleApp.xcodeproj` in `XCode`


### PR DESCRIPTION
The current clone path doesn't have the correct permissions.

This is what happens with the current clone path:

```
➜  Projects git clone git@github.com:catalinmiron/react-native-dribbble-app.git
Cloning into 'react-native-dribbble-app'...
warning: templates not found /Users/amila/.git-templates
Warning: Permanently added the RSA host key for IP address '192.30.252.129' to the list of known hosts.
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Here is the output of the fixed version:

```
➜  Projects git clone https://github.com/catalinmiron/react-native-dribbble-app.git
Cloning into 'react-native-dribbble-app'...
warning: templates not found /Users/amila/.git-templates
remote: Counting objects: 345, done.
remote: Total 345 (delta 0), reused 0 (delta 0), pack-reused 345
Receiving objects: 100% (345/345), 5.30 MiB | 1.81 MiB/s, done.
Resolving deltas: 100% (153/153), done.
Checking connectivity... done.
➜  Projects
```
