### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![BuddyBuild](https://dashboard.buddybuild.com/api/statusImage?appID=5654dbf613d2b801001aaa4f&branch=master&build=latest)](https://dashboard.buddybuild.com/apps/5654dbf613d2b801001aaa4f/build/latest)
 
-###Dribbble app built with React Native
+### Dribbble app built with React Native
 
 A [Dribbble](http://dribbble.com) app build with [React Native](https://github.com/facebook/react-native).
 
 ![dribbble_app_screenshot](https://cloud.githubusercontent.com/assets/2805320/8113463/db61b072-1076-11e5-8aa2-52417f019ea0.jpg)
 
-####Preview
+#### Preview
 ![dribbble_app_flow](https://cloud.githubusercontent.com/assets/2805320/8127634/25311eb0-1101-11e5-83aa-06dcc2d69da3.gif)
 
 
@@ -23,7 +23,7 @@ Plugins used:
 - [React native Parallax view](https://github.com/lelandrichardson/react-native-parallax-view)
 - [React native vector icons](https://github.com/oblador/react-native-vector-icons)
 
-####How to run it locally
+#### How to run it locally
 
 - Clone this repo `git clone git@github.com:catalinmiron/react-native-dribbble-app.git`
 - `cd react-native-dribbble-app`
@@ -32,7 +32,7 @@ Plugins used:
 - Press `cmd+r` to build it
 
 
-####Improvements
+#### Improvements
 - [x] add icons in TabBar
 - [ ] refactor 'facebook-movies' fetching logic
 - [x] add author view


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
